### PR TITLE
implement websocket Newton API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
 python-dotenv
+# newton.co uses v2.x JavaScript SocketIO lib, it corresponds
+# to python-socketio v4.x and python-engineio v3.x and more recent
+# versions of python libraries won't work with newton.co websocket API
+# pip install 'python-socketio>=4,<5' --user
+python-socketio>=4,<5
+websocket-client


### PR DESCRIPTION
some of the Newton API is available via websocket only, for example: chart data, order book, trading history
let's implement the functionality to query that data in this library